### PR TITLE
index: Fix variadic argument formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+coverage
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+
+BIN := node_modules/.bin
+REPORTER ?= spec
+SRC = index.js
+TESTS = test.js
+
+test: node_modules
+	$(BIN)/mocha \
+	  --reporter $(REPORTER)
+
+coverage: $(SRC) $(TESTS)
+	$(BIN)/istanbul cover $(BIN)/_mocha -- \
+	  --reporter $(REPORTER)
+
+node_modules: package.json
+	@npm install
+	@touch $@
+
+clean:
+	rm -rf coverage
+
+.PHONY: test clean

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = Logger;
 
 /**
  * Initialize `Logger`
- * 
+ *
  * @param {Stream} stream
  * @api public
  */
@@ -28,19 +28,19 @@ function Logger(stream){
 
 /**
  * Add `type` with `color`.
- * 
+ *
  * Example:
- * 
+ *
  *    logger.type('log', '36m');
  *    logger.log('woot %d', 9);
- * 
+ *
  *    logger.type('error', '36m', function(){
  *      logger.end();
  *      process.exit(1);
  *    });
- * 
+ *
  *    logger.error('%s', err.stack);
- * 
+ *
  * @param {String} type
  * @param {String} color
  * @param {Function} fn
@@ -63,7 +63,7 @@ Logger.prototype.type = function(type, color, fn){
 
 /**
  * Log `type`, `color` with `args`.
- * 
+ *
  * @param {String} type
  * @param {String} color
  * @param {Function} fn
@@ -74,15 +74,16 @@ Logger.prototype.__log__ = function(type, color, args){
   if (!this.wrote) this.stream.write('\n');
   var pad = this.padleft(type);
   var msg = '%s\033[%s%s\033[m';
-  if (args.length > 0) msg += ' : %s';
-  msg = fmt.apply(null, [msg, pad, color, type].concat(args));
+  if (args.length) msg += ' : ';
+  msg = fmt(msg, pad, color, type);
+  if (args.length) msg += fmt.apply(null, args);
   this.stream.write(msg);
   return this;
 };
 
 /**
  * Pad `type` left.
- * 
+ *
  * @param {String} type
  * @return {String}
  * @api private
@@ -95,7 +96,7 @@ Logger.prototype.padleft = function(type){
 
 /**
  * End.
- * 
+ *
  * @api public
  */
 

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "dependencies": {
     "max-component": "^1.0.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "better-assert": "^1.0.1",
+    "istanbul": "^0.3.2",
+    "mocha": "^1.21.4"
+  }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,79 @@
+
+var assert = require('better-assert');
+var Writable = require('stream').Writable;
+var Logger = require('./');
+
+describe('Logger(stream)', function(){
+  var logger, stream;
+
+  beforeEach(function(){
+    stream = new Writable;
+    stream._write = function(chunk, enc, fn){
+      (this.data = this.data || []).push(chunk);
+      fn();
+    };
+    logger = new Logger(stream);
+  });
+
+  it('should not require new', function(){
+    var logger = Logger(stream);
+    assert(logger instanceof Logger);
+  });
+
+  describe('#type(name)', function () {
+    it('should default to 30m', function(){
+      logger.type('foo');
+      logger.foo('bar');
+      assert('\n   \u001b[30mfoo\u001b[m : bar' == stream.data.join(''));
+    });
+  });
+
+  describe('#type(name, color)', function(){
+    it('should add a "type" method', function(){
+      assert('function' != typeof logger.foo);
+      logger.type('foo', '36m');
+      assert('function' == typeof logger.foo);
+    });
+
+    it('should add \\n on first write', function() {
+      logger.type('foo', '36m');
+      logger.foo('bar');
+      assert('\n' == stream.data[0]);
+    });
+
+    it('should wrap "name" in color', function(){
+      logger.type('foo', '36m');
+      logger.foo('bar');
+      var str = stream.data.join('').toString();
+      assert('\n   \u001b[36mfoo\u001b[m : bar' == str);
+    });
+
+    it('should format variadic arguments', function(){
+      logger.type('foo', '36m');
+      logger.foo('bar %s', 'baz');
+      var str = stream.data.join('').toString();
+      assert('\n   \u001b[36mfoo\u001b[m : bar baz' == str);
+    });
+  });
+
+  describe('#type(name, color, fn)', function(){
+    it('should add a "type" method and invoke fn', function(){
+      var invoked = false;
+      logger.type('foo', '36m', function(){
+        invoked = true;
+      });
+      logger.foo('bar');
+      assert(invoked);
+    });
+  });
+
+  describe('#end()', function(){
+    it('should print \\n\\n', function() {
+      logger.type('foo', '36m');
+      logger.foo('bar');
+      stream.data = [];
+      logger.end();
+      assert('\n\n' == stream.data[0]);
+    });
+  });
+});


### PR DESCRIPTION
Fixes additional argument formatting.  Currently, `logger.foo('bar %s',
'baz')` will print _"foo : bar %s baz"_.  This patch will now yield _"foo : bar baz"_.

Also, add tests / code-coverage reporting to prove this bug is fixed :)
