### PR TITLE
Use `longest` instead of `max`

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
  * Module dependencies.
  */
 
-var max = require('max-component');
+var longest = require('longest');
 var fmt = require('util').format;
 var assert = require('assert');
 
@@ -92,7 +92,7 @@ Logger.prototype.__log__ = function(type, color, args){
  */
 
 Logger.prototype.padleft = function(type){
-  var len = max(this.types, '.length');
+  var len = longest(this.types).length;
   return Array(this.indent + 1 + len - type.length).join(' ');
 };
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "max-component": "^1.0.0"
+    "longest": "^0.2.1"
   },
   "devDependencies": {
     "better-assert": "^1.0.1",


### PR DESCRIPTION
This fixes [issues](https://github.com/google/web-starter-kit/issues/490#issuecomment-60008429) with npm due to a stupid deeply nested dependency (https://gist.github.com/sindresorhus/accb44d6eff6cbc24984#file-gistfile1-txt-L20). Also gets rid of that long dependency tree which shouldn't be needed for a log module.
