### PR TITLE
index: Fix support for logger.wrote('...')

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,10 @@ Logger.prototype.type = function(type, color, fn){
  */
 
 Logger.prototype.__log__ = function(type, color, args){
-  if (!this.wrote) this.stream.write('\n');
+  if (!this._wrote) {
+    this.stream.write('\n');
+    this._wrote = true;
+  }
   var pad = this.padleft(type);
   var msg = '%s\033[%s%s\033[m';
   if (args.length) msg += ' : ';

--- a/test.js
+++ b/test.js
@@ -26,6 +26,12 @@ describe('Logger(stream)', function(){
       logger.foo('bar');
       assert('\n   \u001b[30mfoo\u001b[m : bar' == stream.data.join(''));
     });
+
+    it('should support #type("wrote")', function(){
+      logger.type('wrote');
+      logger.wrote('foo');
+      assert('\n   \u001b[30mwrote\u001b[m : foo' == stream.data.join(''));
+    })
   });
 
   describe('#type(name, color)', function(){


### PR DESCRIPTION
Just ran into very strange behaviour when attempting to
`logger.type('wrote')` and `logger.wrote('stuff')`.  This
patch prefixes a private variable `Logger#wrote` with an
underscore (`Logger#_wrote`), which is _less likely_ to
be used as a logging method.  It's a hack, but not sure
how else to handle this.

I'm also setting a `wrote` value after the first write,
which the prior implementation never seemed to do?
